### PR TITLE
Remove bottom Docusaurus boilerplate

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
@@ -34,9 +33,6 @@ export default function Home(): ReactNode {
       title={`Home | ${siteConfig.title}`}
       description="Home page for the Cambridge CS Colleges Wiki">
       <HomepageHeader />
-      <main>
-        <HomepageFeatures />
-      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- strip the homepage feature section from the landing page

## Testing
- `npm run typecheck` *(fails: Cannot find module '@docusaurus/types' etc.)*