### PR TITLE
Fix missing logo and add placeholder docs

### DIFF
--- a/docs/central/jesus.md
+++ b/docs/central/jesus.md
@@ -1,0 +1,3 @@
+# Jesus College
+
+This page is under construction. Information about Jesus College will be added soon.

--- a/docs/central/trinity.md
+++ b/docs/central/trinity.md
@@ -1,0 +1,3 @@
+# Trinity College
+
+This page is under construction. Information about Trinity College will be added soon.

--- a/docs/hill/churchill.md
+++ b/docs/hill/churchill.md
@@ -1,0 +1,3 @@
+# Churchill College
+
+This page is under construction. Information about Churchill College will be added soon.

--- a/docs/river/st-johns.md
+++ b/docs/river/st-johns.md
@@ -1,0 +1,3 @@
+# St John's College
+
+This page is under construction. Information about St John's College will be added soon.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,7 +43,7 @@ const config: Config = {
         title: 'Cambridge CS Colleges',
         logo: {
           alt: 'Cambridge University Crest',
-          src: 'img/cambridge-crest.png',
+          src: 'img/logo.svg',
         },
         items: [
           {


### PR DESCRIPTION
## Summary
- fix navbar logo path
- add placeholder pages referenced in sidebar

## Testing
- `npm run typecheck` *(fails: cannot find module '@docusaurus/types')*