### PR TITLE
Add 3D canvas page

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "three": "^0.161.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,9 @@ function HomepageHeader() {
           <Link className="button button--secondary button--lg" to="/docs/intro">
             Browse Colleges
           </Link>
+          <Link className="button button--secondary button--lg" to="/three" style={{marginLeft: '1rem'}}>
+            3D Demo
+          </Link>
         </div>
       </div>
     </header>

--- a/src/pages/three.tsx
+++ b/src/pages/three.tsx
@@ -1,0 +1,79 @@
+import React, {useRef, useEffect} from 'react';
+import Layout from '@theme/Layout';
+
+import * as THREE from 'three';
+
+function ThreeScene() {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!mountRef.current) return;
+
+    const width = mountRef.current.clientWidth;
+    const height = 500; // fixed height
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({antialias: true});
+    renderer.setSize(width, height);
+    mountRef.current.appendChild(renderer.domElement);
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshNormalMaterial();
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    const particleCount = 500;
+    const particlesGeometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(particleCount * 3);
+    for (let i = 0; i < particleCount; i++) {
+      positions[i * 3] = (Math.random() - 0.5) * 10;
+      positions[i * 3 + 1] = (Math.random() - 0.5) * 10;
+      positions[i * 3 + 2] = (Math.random() - 0.5) * 10;
+    }
+    particlesGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const particlesMaterial = new THREE.PointsMaterial({color: 0xffffff, size: 0.05});
+    const particles = new THREE.Points(particlesGeometry, particlesMaterial);
+    scene.add(particles);
+
+    camera.position.z = 5;
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    const handleResize = () => {
+      const newWidth = mountRef.current?.clientWidth || width;
+      camera.aspect = newWidth / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(newWidth, height);
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      mountRef.current?.removeChild(renderer.domElement);
+      geometry.dispose();
+      material.dispose();
+      particlesGeometry.dispose();
+      renderer.dispose();
+    };
+  }, []);
+
+  return <div ref={mountRef} style={{width: '100%', height: 500}} />;
+}
+
+export default function ThreePage() {
+  return (
+    <Layout title="3D Demo" description="Example 3D canvas with particle effects">
+      <div style={{padding: '1rem'}}>
+        <h1>3D Demo</h1>
+        <ThreeScene />
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add three.js dependency
- add a link to a new 3D demo page
- implement 3D demo page with rotating cube and particles

## Testing
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run build` *(fails: docusaurus not found)*
