### PR TITLE
Apply new color scheme

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -9,7 +9,7 @@
 }
 
 .feature {
-  background: #2c313c;
+  background: #363a4d;
   border-radius: 8px;
   padding: 1.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,15 +7,15 @@
   --ifm-heading-font-family: 'Inter', system-ui, sans-serif;
 
   /* Color theming */
-  --ifm-color-primary: #00BDB6;       /* Cambridge blue accent (warm blue) */
-  --ifm-color-primary-dark: #00A39E;  /* a slightly darker shade for hover states */
-  --ifm-color-primary-light: #AFF5F2; /* a very light tint for highlights */
+  --ifm-color-primary: #9CD8D9;       /* teal accent */
+  --ifm-color-primary-dark: #8FACCB;  /* slightly darker shade */
+  --ifm-color-primary-light: #817FBC; /* light purple tint */
 
   /* Layout and spacing */
   --ifm-content-width: 800px;
   --ifm-font-size-base: 17px;
   --ifm-line-height-base: 1.7;
-  --ifm-background-gradient: linear-gradient(180deg, #363a4d 0%, #2c313c 100%);
+  --ifm-background-gradient: linear-gradient(180deg, #363a4d 0%, #363a4d 100%);
 }
 
 /* General body background for a dark sleek look */

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -8,7 +8,7 @@
   text-align: center;
   position: relative;
   overflow: hidden;
-  background: linear-gradient(135deg, #00bdb6 0%, #00535c 100%);
+  background: linear-gradient(135deg, #9CD8D9 0%, #817FBC 100%);
   color: #fff;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## Summary
- switch the site's primary colors to #9CD8D9, #8FACCB and #817FBC
- use #363A4D backgrounds where possible

## Testing
- `npm run typecheck` *(fails: Module '"react"' has no exported member 'useRef')*