### PR TITLE
Improve theme switching and sidebar overflow

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,39 +6,51 @@
   --ifm-font-family-monospace: 'JetBrains Mono', monospace;
   --ifm-heading-font-family: 'Inter', system-ui, sans-serif;
 
-  /* Color theming */
-  --ifm-color-primary: #9CD8D9;       /* teal accent */
-  --ifm-color-primary-dark: #8FACCB;  /* slightly darker shade */
-  --ifm-color-primary-light: #817FBC; /* light purple tint */
-
-  /* Layout and spacing */
+  /* Shared layout */
   --ifm-content-width: 800px;
   --ifm-font-size-base: 17px;
   --ifm-line-height-base: 1.7;
+}
+
+html[data-theme='dark'] {
+  --ifm-color-primary: #9CD8D9;       /* teal accent */
+  --ifm-color-primary-dark: #8FACCB;  /* slightly darker shade */
+  --ifm-color-primary-light: #817FBC; /* light purple tint */
   --ifm-background-gradient: linear-gradient(180deg, #363a4d 0%, #363a4d 100%);
+  --navbar-bg-color: #363a4d;
+  --body-text-color: #f0f0f0;
+}
+
+html[data-theme='light'] {
+  --ifm-color-primary: #0066cc;       /* stronger blue for light mode */
+  --ifm-color-primary-dark: #005bb5;
+  --ifm-color-primary-light: #4d94ff;
+  --ifm-background-gradient: linear-gradient(180deg, #ffffff 0%, #f5f5f5 100%);
+  --navbar-bg-color: #ffffff;
+  --body-text-color: #222222;
 }
 
 /* General body background for a dark sleek look */
 body {
   background: var(--ifm-background-gradient);
-  color: #f0f0f0;
+  color: var(--body-text-color);
 }
 
 /* Navbar customization: match dark theme */
 .navbar {
-  background-color: #363a4d;
+  background-color: var(--navbar-bg-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 /* Highlight Home and University Website buttons */
 .navbar__title,
 .navbar__link[href="https://www.cam.ac.uk"] {
-  color: #9CD8D9 !important;
+  color: var(--ifm-color-primary) !important;
 }
 
 .navbar__title:hover,
 .navbar__link[href="https://www.cam.ac.uk"]:hover {
-  color: #8FACCB !important;
+  color: var(--ifm-color-primary-dark) !important;
 }
 
 /* Increase padding around main content for readability */
@@ -53,5 +65,6 @@ body {
 /* Ensure the docs sidebar is scrollable */
 .theme-doc-sidebar-container {
   overflow-y: auto;
+  overflow-x: hidden;
   max-height: calc(100vh - var(--ifm-navbar-height));
 }


### PR DESCRIPTION
## Summary
- adjust CSS variables for light/dark themes
- use theme variables in navbar and body
- hide horizontal scroll in docs sidebar

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script)*